### PR TITLE
Extract hrefs from links, add to end of text and reference them.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ string output = converter.Convert(element);
 ```html
 <div id="page">
     <header>
-        <a href="/" class="site-logo">
+        <a href="http://example.com" class="site-logo">
         	<img src="logo.png" alt="Logo" />
         </a>
         <h1>
@@ -100,7 +100,7 @@ string output = converter.Convert(element);
 Output:
 
 ```
-[IMG: Logo]
+[IMG: Logo] [1]
 
 ++++++++++
 Site title
@@ -125,7 +125,8 @@ But maybe a table is nicer:
 | Key | Value |
 
 | One | Value |
-```
+
+[1] http://example.com```
 
 ## License
 

--- a/Textify.Tests/ComplexTest.cs
+++ b/Textify.Tests/ComplexTest.cs
@@ -2,38 +2,44 @@ using Xunit;
 
 namespace Textify.Tests
 {
-    public class ReadmeTest : BaseTest
+    public class ComplexTest : BaseTest
     {
         [Fact]
-        public void ReadmeShouldRenderAsDisplayed()
+        public void ComplexShouldRenderAsExpected()
         {
             string input = @"<div id=""page"">
     <header>
-        <a href=""http://example.com"" class=""site-logo"">
+        
+        <h1>
+            <a href=""http://example.com"" class=""site-logo"">
         	<img src=""logo.png"" alt=""Logo"" />
         </a>
-        <h1>
-            Site title
         </h1>
     </header>
     <main>
     	<article>
-        	<h2>Article title</h2>
+
+            <h1>Article title</h1>
+
+        	<h2><a name=""anchor1""><img src=""test.gif"" />Article title</a></h2>
             
             <p>
                 <strong>Lorem ipsum</strong> dolor sit amet, consectetur adipiscing elit,
                 sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
             </p>
 
-            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco
+            <h2><a name=""anchor2""><svg />Article title</a></h2>
+
+            <p>Ut enim ad minim <a href=""#anchor2"">ignored</a> veniam, <a href=""external"">quis</a> nostrud exercitation ullamco
             laboris nisi ut aliquip ex ea commodo consequat.</p>
             
             Here is a list of things anyway:
 
             <ul>
                 <li>One</li>
-                <li>Two</li>
-                <li>Three</li>
+                <li><a href=""#anchor2""><b>T</b>wo</a></li>
+                <li><a href=""external"">Three</a></li>
+                <li><a href=""external""></a></li>
             </ul>
 
             But maybe a table is nicer:<br><br>
@@ -52,10 +58,12 @@ namespace Textify.Tests
     </main>
 </div>";
 
-            string expected = @"[IMG: Logo] [1]
+            string expected = @"========================
+[IMG: Logo] [1]
+========================
 
 ========================
-Site title
+Article title
 ========================
 
 ------------------------
@@ -64,13 +72,18 @@ Article title
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
 
-Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+------------------------
+Article title
+------------------------
+
+Ut enim ad minim ignored veniam, quis [2] nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
 
 Here is a list of things anyway:
 
 * One
 * Two
-* Three
+* Three [2]
+* [2]
 
 But maybe a table is nicer:
 
@@ -78,7 +91,8 @@ But maybe a table is nicer:
 
 | One | Value |
 
-[1] http://example.com".Replace("\r\n","\n");
+[1] http://example.com
+[2] external".Replace("\r\n","\n");
 
             RunConversion(input, expected);
         }

--- a/Textify.Tests/HeadingsTests.cs
+++ b/Textify.Tests/HeadingsTests.cs
@@ -5,43 +5,45 @@ namespace Textify.Tests
     public class HeadingsTests : BaseTest
     {
         [Theory]
-        [InlineData("<h1>Test</h1>", "++++\nTest\n++++")]
-        [InlineData("\n<h1>\nTest</h1>", "++++\nTest\n++++")]
-        [InlineData("\t<h1>Test1<br>Test2</h1>", "+++++\nTest1\nTest2\n+++++")]
-        [InlineData("<h1>Test</h1><h1>Test2</h1>", "++++\nTest\n++++\n\n+++++\nTest2\n+++++")]
-        [InlineData("<h1>Test</h1> <h1>Test2</h1>", "++++\nTest\n++++\n\n+++++\nTest2\n+++++")]
-        [InlineData("<h2>Test</h2>", "----\nTest\n----")]
-        [InlineData("<h1>Test</h1><h2>Test</h2>", "++++\nTest\n++++\n\n----\nTest\n----")]
-        [InlineData("<h3>Test</h3>", "Test\n----")]
-        [InlineData("<h3><strong>Test</strong></h3>", "Test\n----")]
-        [InlineData("<h3> <strong>Test</strong></h3>", "Test\n----")]
-        [InlineData("<h3> <strong> Test</strong></h3>", "Test\n----")]
-        [InlineData("<h3>Ha. <strong> Test</strong></h3>", "Ha. Test\n--------")]
-        [InlineData("<p>Paragraph</p><h2>Title</h2>", "Paragraph\n\n-----\nTitle\n-----")]
-        [InlineData("<p>Paragraph</p><h3>Title</h3>", "Paragraph\n\nTitle\n-----")]
+        [InlineData("<h1>Test</h1>", "========================\nTest\n========================")]
+        [InlineData("\n<h1>\nTest</h1>", "========================\nTest\n========================")]
+        [InlineData("\t<h1>Test1<br>Test2</h1>", "========================\nTest1\nTest2\n========================")]
+        [InlineData("<h1>Test</h1><h1>Test2</h1>", "========================\nTest\n========================\n\n========================\nTest2\n========================")]
+        [InlineData("<h1>Test</h1> <h1>Test2</h1>", "========================\nTest\n========================\n\n========================\nTest2\n========================")]
+        [InlineData("<h2>Test</h2>", "------------------------\nTest\n------------------------")]
+        [InlineData("<h1>Test</h1><h2>Test</h2>", "========================\nTest\n========================\n\n------------------------\nTest\n------------------------")]
+        [InlineData("<h3>Test</h3>", "Test")]
+        [InlineData("<h3><strong>Test</strong></h3>", "Test")]
+        [InlineData("<h3> <strong>Test</strong></h3>", "Test")]
+        [InlineData("<h3> <strong> Test</strong></h3>", "Test")]
+        [InlineData("<h3>Ha. <strong> Test</strong></h3>", "Ha. Test")]
+        [InlineData("<p>Paragraph</p><h2>Title</h2>", "Paragraph\n\n------------------------\nTitle\n------------------------")]
+        [InlineData("<p>Paragraph</p><h2>Title</h2>test", "Paragraph\n\n------------------------\nTitle\n------------------------\n\ntest")]
+        [InlineData("<p>Paragraph</p><h3>Title</h3>", "Paragraph\n\nTitle")]
+        [InlineData("<p>Paragraph</p><h3>Title</h3>test", "Paragraph\n\nTitle\n\ntest")]
         public void ShouldConvertHeadings(string input, string expected)
         {
             RunConversion(input, expected);
         }
 
         [Theory]
-        [InlineData("<h1>First line<br>Second line</h1>", "+++++++++++\nFirst line\nSecond line\n+++++++++++")]
-        [InlineData("<h1>First line<br>  Second line</h1>", "+++++++++++\nFirst line\nSecond line\n+++++++++++")]
-        [InlineData("<h1>First line<br>\n\tSecond line</h1>", "+++++++++++\nFirst line\nSecond line\n+++++++++++")]
+        [InlineData("<h1>First line<br>Second line</h1>", "========================\nFirst line\nSecond line\n========================")]
+        [InlineData("<h1>First line<br>  Second line</h1>", "========================\nFirst line\nSecond line\n========================")]
+        [InlineData("<h1>First line<br>\n\tSecond line</h1>", "========================\nFirst line\nSecond line\n========================")]
         public void ShouldConvertMultilineHeadings(string input, string expected)
         {
             RunConversion(input, expected);
         }
 
         [Theory]
-        [InlineData("<h1></h1>", "")]
-        [InlineData("<h1></h1>\nTest", "Test")]
-        [InlineData("<h2></h2>", "")]
+        [InlineData("<h1></h1>", "========================")]
+        [InlineData("<h1></h1>\nTest", "========================\n\nTest")]
+        [InlineData("<h2></h2>", "------------------------")]
         [InlineData("<h3></h3>", "")]
         [InlineData("<h4></h4>", "")]
         [InlineData("<h5></h5>", "")]
         [InlineData("<h6></h6>", "")]
-        public void ShouldIgnoreEmptyHeadings(string input, string expected)
+        public void ShouldOnlyCreateDividerForEmptyHeadings(string input, string expected)
         {
             RunConversion(input, expected);
         }
@@ -51,7 +53,7 @@ namespace Textify.Tests
         [InlineData("<h5>Test</h5>", "Test")]
         [InlineData("<h6>Test</h6>", "Test")]
         [InlineData("<div>Hey</div><h6>Test</h6>", "Hey\n\nTest")]
-        [InlineData("<h1>Hey</h1><h6>Test</h6>", "+++\nHey\n+++\n\nTest")]
+        [InlineData("<h1>Hey</h1><h6>Test</h6>", "========================\nHey\n========================\n\nTest")]
         [InlineData("<h6>Test</h6> Random text", "Test\n\nRandom text")]
         [InlineData("<h6>Test</h6> <span>Text</span>", "Test\n\nText")]
         public void ShouldConvertSimpleHeadings(string input, string expected)

--- a/Textify.Tests/LinksTests.cs
+++ b/Textify.Tests/LinksTests.cs
@@ -13,6 +13,7 @@ namespace Textify.Tests
         [InlineData("Prefix.\n<a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
         [InlineData("Prefix.\n <a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
         [InlineData("<a href=\"link\">Test</a> and <a href=\"link2\">Another</a> and <a href=\"link\">Test Again</a>", "Test [1] and Another [2] and Test Again [1]\n\n[1] link\n[2] link2")]
+        [InlineData("<h1>A<a href=\"link\">b</a>c</h1>", "========================\nAb [1]c\n========================\n\n[1] link")]
         public void ShouldConvertLinks(string input, string expected)
         {
             RunConversion(input, expected);
@@ -22,6 +23,14 @@ namespace Textify.Tests
         [InlineData("Hi <a href=\"link\"></a>---", "Hi [1]---\n\n[1] link")]
         [InlineData("Hi<a href=\"link\"></a>.", "Hi [1].\n\n[1] link")]
         public void ShouldCollapseEmptyLinks(string input, string expected)
+        {
+            RunConversion(input, expected);
+        }
+
+        [Theory]
+        [InlineData("Hi <a name=\"link\"></a>---", "Hi ---")]
+        [InlineData("Hi<a name=\"link\"></a>.", "Hi.")]
+        public void ShouldCollapseAnchorLinks(string input, string expected)
         {
             RunConversion(input, expected);
         }

--- a/Textify.Tests/LinksTests.cs
+++ b/Textify.Tests/LinksTests.cs
@@ -5,21 +5,22 @@ namespace Textify.Tests
     public class LinksTests : BaseTest
     {
         [Theory]
-        [InlineData("<a href=\"link\">Test</a>", "Test")]
-        [InlineData("<a href=\"link\">Test</a> suff", "Test suff")]
-        [InlineData("<a href=\"link\">Test</a>  suff", "Test suff")]
-        [InlineData("Prefix. <a href=\"link\">Test</a>", "Prefix. Test")]
-        [InlineData("Prefix. \n<a href=\"link\">Test</a>", "Prefix. Test")]
-        [InlineData("Prefix.\n<a href=\"link\">Test</a>", "Prefix. Test")]
-        [InlineData("Prefix.\n <a href=\"link\">Test</a>", "Prefix. Test")]
+        [InlineData("<a href=\"link\">Test</a>", "Test (1)\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a> suff", "Test (1) suff\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a>  suff", "Test (1) suff\n\n[1] link")]
+        [InlineData("Prefix. <a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
+        [InlineData("Prefix. \n<a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
+        [InlineData("Prefix.\n<a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
+        [InlineData("Prefix.\n <a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a> and <a href=\"link2\">Another</a> and <a href=\"link\">Test Again</a>", "Test (1) and Another (2) and Test Again (1)\n\n[1] link\n[2] link2")]
         public void ShouldConvertLinks(string input, string expected)
         {
             RunConversion(input, expected);
         }
 
         [Theory]
-        [InlineData("Hi <a href=\"link\"></a>---", "Hi ---")]
-        [InlineData("Hi<a href=\"link\"></a>.", "Hi.")]
+        [InlineData("Hi <a href=\"link\"></a>---", "Hi (1)---\n\n[1] link")]
+        [InlineData("Hi<a href=\"link\"></a>.", "Hi (1).\n\n[1] link")]
         public void ShouldCollapseEmptyLinks(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify.Tests/LinksTests.cs
+++ b/Textify.Tests/LinksTests.cs
@@ -5,22 +5,22 @@ namespace Textify.Tests
     public class LinksTests : BaseTest
     {
         [Theory]
-        [InlineData("<a href=\"link\">Test</a>", "Test (1)\n\n[1] link")]
-        [InlineData("<a href=\"link\">Test</a> suff", "Test (1) suff\n\n[1] link")]
-        [InlineData("<a href=\"link\">Test</a>  suff", "Test (1) suff\n\n[1] link")]
-        [InlineData("Prefix. <a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
-        [InlineData("Prefix. \n<a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
-        [InlineData("Prefix.\n<a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
-        [InlineData("Prefix.\n <a href=\"link\">Test</a>", "Prefix. Test (1)\n\n[1] link")]
-        [InlineData("<a href=\"link\">Test</a> and <a href=\"link2\">Another</a> and <a href=\"link\">Test Again</a>", "Test (1) and Another (2) and Test Again (1)\n\n[1] link\n[2] link2")]
+        [InlineData("<a href=\"link\">Test</a>", "Test [1]\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a> suff", "Test [1] suff\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a>  suff", "Test [1] suff\n\n[1] link")]
+        [InlineData("Prefix. <a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
+        [InlineData("Prefix. \n<a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
+        [InlineData("Prefix.\n<a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
+        [InlineData("Prefix.\n <a href=\"link\">Test</a>", "Prefix. Test [1]\n\n[1] link")]
+        [InlineData("<a href=\"link\">Test</a> and <a href=\"link2\">Another</a> and <a href=\"link\">Test Again</a>", "Test [1] and Another [2] and Test Again [1]\n\n[1] link\n[2] link2")]
         public void ShouldConvertLinks(string input, string expected)
         {
             RunConversion(input, expected);
         }
 
         [Theory]
-        [InlineData("Hi <a href=\"link\"></a>---", "Hi (1)---\n\n[1] link")]
-        [InlineData("Hi<a href=\"link\"></a>.", "Hi (1).\n\n[1] link")]
+        [InlineData("Hi <a href=\"link\"></a>---", "Hi [1]---\n\n[1] link")]
+        [InlineData("Hi<a href=\"link\"></a>.", "Hi [1].\n\n[1] link")]
         public void ShouldCollapseEmptyLinks(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify.Tests/ListsTests.cs
+++ b/Textify.Tests/ListsTests.cs
@@ -8,6 +8,8 @@ namespace Textify.Tests
         [InlineData("<ul></ul>", "")]
         [InlineData("<ul><li>Test 1</li></ul>", "* Test 1")]
         [InlineData("<ul><li>Test 1</li><li>Test 2</li><li>Test 3</li></ul>", "* Test 1\n* Test 2\n* Test 3")]
+        [InlineData("<ul><li>Test 1</li><li>Test 2</li><li>Test 3</li></ul>", "* Test 1\n* Test 2\n* Test 3")]
+        [InlineData("<ul><li>Test 1: <a href=\"link1\">Link1</a></li><li>Test 2: <a href=\"link2\">Link2</a></li><li>Test 3: <a href=\"link1\">Link1</a></li></ul>", "* Test 1: Link1 [1]\n* Test 2: Link2 [2]\n* Test 3: Link1 [1]\n\n[1] link1\n[2] link2")]
         public void ShouldConvertLists(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify.Tests/ListsTests.cs
+++ b/Textify.Tests/ListsTests.cs
@@ -8,20 +8,19 @@ namespace Textify.Tests
         [InlineData("<ul></ul>", "")]
         [InlineData("<ul><li>Test 1</li></ul>", "* Test 1")]
         [InlineData("<ul><li>Test 1</li><li>Test 2</li><li>Test 3</li></ul>", "* Test 1\n* Test 2\n* Test 3")]
-        [InlineData("<ul><li>Test 1</li><li>Test 2</li><li>Test 3</li></ul>", "* Test 1\n* Test 2\n* Test 3")]
         [InlineData("<ul><li>Test 1: <a href=\"link1\">Link1</a></li><li>Test 2: <a href=\"link2\">Link2</a></li><li>Test 3: <a href=\"link1\">Link1</a></li></ul>", "* Test 1: Link1 [1]\n* Test 2: Link2 [2]\n* Test 3: Link1 [1]\n\n[1] link1\n[2] link2")]
         public void ShouldConvertLists(string input, string expected)
         {
             RunConversion(input, expected);
         }
 
-        //[Theory]
-        //[InlineData("<ul><li>Test 1<ul><li>Nested</li></ul></li</ul>", "* Test 1\n\n\t* Nested")]
-        //[InlineData("<ul><li>Test 1<ul><li>Nested</li></ul></li><li>Test 2</li></ul>", "* Test 1\n\n\t* Nested\n\n* Test 2")]
-        //// TODO: add spaces
-        //public void ShouldRenderNestedLists(string input, string expected)
-        //{
-        //    RunConversion(input, expected);
-        //}
+        [Theory]
+        [InlineData("<ul><li>Test 1<ul><li>Nested</li></ul></li</ul>", "* Test 1\n\n\t* Nested")]
+        [InlineData("<ul><li>Test 1<ul><li>Nested 1</li><li>Nested 2</li><li>Nested 3</li></ul></li><li>Test 2</li></ul>", "* Test 1\n\n\t* Nested 1\n\t* Nested 2\n\t* Nested 3\n\n* Test 2")]
+        [InlineData("<ul><li>Test 1<ul><li>Nested 1 <ul><li>Nested 1a</li><li>Nested 1b</li></ul></li></ul></li><li>Test 2<ul><li>Nested 2 <ul><li>Nested 2a</li><li>Nested 2b</li></ul></li><li>Nested 3 <ul><li>Nested 3a</li><li>Nested 3b</li></ul></li></ul></li><li>Test 3</li></ul>", "* Test 1\n\n\t* Nested 1\n\n\t\t* Nested 1a\n\t\t* Nested 1b\n\n* Test 2\n\n\t* Nested 2\n\n\t\t* Nested 2a\n\t\t* Nested 2b\n\n\t* Nested 3\n\n\t\t* Nested 3a\n\t\t* Nested 3b\n\n* Test 3")]
+        public void ShouldRenderNestedLists(string input, string expected)
+        {
+            RunConversion(input, expected);
+        }
     }
 }

--- a/Textify.Tests/ListsTests.cs
+++ b/Textify.Tests/ListsTests.cs
@@ -9,6 +9,7 @@ namespace Textify.Tests
         [InlineData("<ul><li>Test 1</li></ul>", "* Test 1")]
         [InlineData("<ul><li>Test 1</li><li>Test 2</li><li>Test 3</li></ul>", "* Test 1\n* Test 2\n* Test 3")]
         [InlineData("<ul><li>Test 1: <a href=\"link1\">Link1</a></li><li>Test 2: <a href=\"link2\">Link2</a></li><li>Test 3: <a href=\"link1\">Link1</a></li></ul>", "* Test 1: Link1 [1]\n* Test 2: Link2 [2]\n* Test 3: Link1 [1]\n\n[1] link1\n[2] link2")]
+        [InlineData("<ul><li>Test 1: <a href=\"link1\">Link1</a></li><li>Test 2: <a href=\"link2\">Link2</a></li><li>Nesting: <ul><li>Test 1: <a href=\"link1\">Link1</a></li><li>Test 2: <a href=\"link2\">Link2</a></li></ul></li><li>Test 3: <a href=\"link1\">Link1</a></li></ul>", "* Test 1: Link1 [1]\n* Test 2: Link2 [2]\n* Nesting:\n\n\t* Test 1: Link1 [1]\n\t* Test 2: Link2 [2]\n\n* Test 3: Link1 [1]\n\n[1] link1\n[2] link2")]
         public void ShouldConvertLists(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify.Tests/ReadmeTest.cs
+++ b/Textify.Tests/ReadmeTest.cs
@@ -1,0 +1,87 @@
+using Xunit;
+
+namespace Textify.Tests
+{
+    public class ReadmeTest : BaseTest
+    {
+        [Fact]
+        public void ReadmeShouldRenderAsDisplayed()
+        {
+            string input = @"<div id=""page"">
+    <header>
+        <a href=""http://example.com"" class=""site-logo"">
+        	<img src=""logo.png"" alt=""Logo"" />
+        </a>
+        <h1>
+            Site title
+        </h1>
+    </header>
+    <main>
+    	<article>
+        	<h2>Article title</h2>
+            
+            <p>
+                <strong>Lorem ipsum</strong> dolor sit amet, consectetur adipiscing elit,
+                sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+            </p>
+
+            <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco
+            laboris nisi ut aliquip ex ea commodo consequat.</p>
+            
+            Here is a list of things anyway:
+
+            <ul>
+                <li>One</li>
+                <li>Two</li>
+                <li>Three</li>
+            </ul>
+
+            But maybe a table is nicer:<br><br>
+            
+            <table>
+                <thead>
+                	<th>Key</th>
+                    <th>Value</th>
+                </thead>
+                <tr>
+                	<td>One</td>
+                    <td>Value</td>
+                </tr>
+            </table>
+        </article>
+    </main>
+</div>";
+
+            string expected = @"[IMG: Logo] [1]
+
+++++++++++
+Site title
+++++++++++
+
+-------------
+Article title
+-------------
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+
+Here is a list of things anyway:
+
+* One
+* Two
+* Three
+
+But maybe a table is nicer:
+
+| Key | Value |
+
+| One | Value |
+
+[1] http://example.com".Replace("\r\n","\n");
+
+            RunConversion(input, expected);
+        }
+
+    }
+}

--- a/Textify.Tests/TextTests.cs
+++ b/Textify.Tests/TextTests.cs
@@ -21,7 +21,7 @@ namespace Textify.Tests
         [Theory]
         [InlineData("My name is: <strong>Nic</strong>", "My name is: Nic")]
         [InlineData("My name is:<strong>Nic</strong>", "My name is:Nic")]
-        [InlineData("Visit \"<a href=\"http://example.com\">Example</strong>\"", "Visit \"Example\" (1)\n\n[1] http://example.com")]
+        [InlineData("Visit \"<a href=\"http://example.com\">Example</strong>\"", "Visit \"Example\" [1]\n\n[1] http://example.com")]
         public void ShouldNotStripWhitespaceBetweenNodes(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify.Tests/TextTests.cs
+++ b/Textify.Tests/TextTests.cs
@@ -21,7 +21,7 @@ namespace Textify.Tests
         [Theory]
         [InlineData("My name is: <strong>Nic</strong>", "My name is: Nic")]
         [InlineData("My name is:<strong>Nic</strong>", "My name is:Nic")]
-        [InlineData("Visit \"<a href=\"http://example.com\">Example</strong>\"", "Visit \"Example\"")]
+        [InlineData("Visit \"<a href=\"http://example.com\">Example</strong>\"", "Visit \"Example\" (1)\n\n[1] http://example.com")]
         public void ShouldNotStripWhitespaceBetweenNodes(string input, string expected)
         {
             RunConversion(input, expected);

--- a/Textify/HtmlTraversal.cs
+++ b/Textify/HtmlTraversal.cs
@@ -15,6 +15,7 @@ namespace Textify
         private int depth;
         private bool lastWasSpace;
         private List<string> links;
+        private const int dividerLength = 24;
 
         public HtmlTraversal()
         {
@@ -80,53 +81,46 @@ namespace Textify
                 case "H1":
                 case "H2":
                 case "H3":
-                    Write("\n\n");
-
-                    HtmlTraversal headingTrav = new HtmlTraversal();
-                    headingTrav.TraverseChildren(element);
-
-                    string headingText = headingTrav.GetString().Trim();
-
-                    if (string.IsNullOrEmpty(headingText))
-                    {
-                        break;
-                    }
-
-                    int dividerLength = headingText.Split('\n').Max(x => x.Length);
-                    string divider;
-
-                    if (tagName == "H1")
-                    {
-                        divider = new string('+', dividerLength);
-                    }
-                    else
-                    {
-                        divider = new string('-', dividerLength);
-                    }
-
-                    if (tagName == "H3")
-                    {
-                        Write(headingText);
-                        Write("\n");
-                        Write(divider);
-                    }
-                    else
-                    {
-                        Write(divider);
-                        Write("\n");
-                        Write(headingText);
-                        Write("\n");
-                        Write(divider);
-                    }
-
-                    Write("\n\n");
-                    break;
-
                 case "H4":
                 case "H5":
                 case "H6":
+
                     Write("\n\n");
+                    switch (tagName)
+                    {
+                        case "H1":
+                            Write(new string('=', dividerLength));
+                            Write("\n");
+                            break;
+                        case "H2":
+                            Write(new string('-', dividerLength));
+                            Write("\n");
+                            break;
+                        case "H3":
+                            Write("\n");
+                            Write("\n");
+                            break;
+                    }
+
                     TraverseChildren(element);
+
+                    if (lineLength > 0)
+                    {
+                        Write("\n");
+
+                        switch (tagName)
+                        {
+                            case "H1":
+                                Write(new string('=', dividerLength));
+                                break;
+                            case "H2":
+                                Write(new string('-', dividerLength));
+                                break;
+                            case "H3":
+                                Write("\n");
+                                break;
+                        }
+                    }
                     Write("\n\n");
                     break;
 
@@ -203,7 +197,7 @@ namespace Textify
                     string hrefAttribute = element.GetAttribute("href");
                     int linkIndex = -1;
 
-                    if (!string.IsNullOrWhiteSpace(hrefAttribute))
+                    if (!string.IsNullOrWhiteSpace(hrefAttribute) && !hrefAttribute.StartsWith("#"))
                     {
                         if (links.Contains(hrefAttribute))
                         {

--- a/Textify/HtmlTraversal.cs
+++ b/Textify/HtmlTraversal.cs
@@ -147,18 +147,9 @@ namespace Textify
                     break;
 
                 case "LI":
-                    HtmlTraversal trav = new HtmlTraversal();
-                    trav.TraverseChildren(element);
-
-                    string itemText = trav.GetString().Trim();
-
-                    if (!string.IsNullOrWhiteSpace(itemText))
-                    {
-                        Write("* ");
-                        Write(itemText);
-                        Write("\n");
-                    }
-
+                    Write("* ");
+                    TraverseChildren(element);
+                    Write("\n");
                     break;
 
                 case "P":

--- a/Textify/HtmlTraversal.cs
+++ b/Textify/HtmlTraversal.cs
@@ -12,6 +12,7 @@ namespace Textify
         private bool justClosedDiv;
         private int lineLength;
         private int newLinesCount;
+        private int depth;
         private bool lastWasSpace;
         private List<string> links;
 
@@ -155,7 +156,9 @@ namespace Textify
                 case "P":
                 case "UL":
                     Write("\n\n");
+                    depth++;
                     TraverseChildren(element);
+                    depth--;
                     Write("\n\n");
                     break;
 
@@ -268,6 +271,14 @@ namespace Textify
                     if (this.lastWasSpace && isSpace)
                     {
                         continue;
+                    }
+
+                    if (this.lineLength == 0)
+                    {
+                        for (int tab = 0; tab < depth - 1; tab++)
+                        {
+                            this.output.Append("\t");
+                        }
                     }
 
                     this.output.Append(c);

--- a/Textify/HtmlTraversal.cs
+++ b/Textify/HtmlTraversal.cs
@@ -26,9 +26,9 @@ namespace Textify
             if (links.Count() > 0)
             {
                 Write("\n\n");
-                for (var linkIndex = 0; linkIndex < links.Count(); linkIndex++)
+                for (int linkIndex = 0; linkIndex < links.Count(); linkIndex++)
                 {
-                    var link = links[linkIndex];
+                    string link = links[linkIndex];
                     Write($"[{linkIndex + 1}] {link}{(linkIndex < links.Count() - 1 ? "\n" : string.Empty)}");
                 }
             }
@@ -207,9 +207,9 @@ namespace Textify
 
                 case "A":
                     string hrefAttribute = element.GetAttribute("href");
-                    var linkIndex = -1;
+                    int linkIndex = -1;
 
-                    if (!string.IsNullOrWhiteSpace((hrefAttribute)))
+                    if (!string.IsNullOrWhiteSpace(hrefAttribute))
                     {
                         if (links.Contains(hrefAttribute))
                         {
@@ -226,7 +226,7 @@ namespace Textify
 
                     if (linkIndex >= 0)
                     {
-                        Write($" ({linkIndex})");
+                        Write($" [{linkIndex}]");
                     }
                     break;
 


### PR DESCRIPTION
This change allows the links to survive the text conversion by extracting the urls (href attributes) during traversal and then appending them as a numbered list to the end of the document.